### PR TITLE
Fix inconsistencies in documentation

### DIFF
--- a/src/pyscaffoldext/custom_extension/templates/readme.template
+++ b/src/pyscaffoldext/custom_extension/templates/readme.template
@@ -7,7 +7,7 @@ ${description}
 Usage
 =====
 
-Just install this package with ``pip install ${project}`` and note that ``putup -h`` shows a new option ``--${project}``. Use this flag to ...
+Just install this package with ``pip install ${project}`` and note that ``putup -h`` shows a new option ``--${package}``. Use this flag to ...
 
 
 Note

--- a/tests/test_generated_extension.py
+++ b/tests/test_generated_extension.py
@@ -20,3 +20,18 @@ def test_generated_extension(tmpfolder, venv_run):
 
     with chdir("the_actual_project"):
         assert '' == venv_run("flake8")
+
+
+def test_generated_extension_without_prefix(tmpfolder, caplog):
+    # Ensure prefix is added by default
+    args = ["--custom-extension", "some_extension"]
+
+    opts = parse_args(args)
+    opts = process_opts(opts)
+    create_project(opts)
+    assert path_exists("pyscaffoldext-some_extension")
+
+    # Ensure an explanation on how to use
+    # `--force` to avoid preffixing is given
+    logs = caplog.text
+    assert '--force' in logs


### PR DESCRIPTION
As I am a lazy person, I bundled togheter 2 changes in only one PR. Please let me know if you want me to split it so the first one can be accepted without the second.

1. Fix extension flag on README (`package` instead of `project`)
2. In the README description, the following example is given:
   `putup --custom-extension notebooks`
  However this throws an error in the current implementation.
  The changes in this commit address that by adding the prefix by default and warning the user instead of raising an exception.