### PR TITLE
Allow ConfigUpdater v3 as a dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ package_dir =
 install_requires =
     importlib-metadata; python_version<"3.8"
     pyscaffold>=4.0.1,<5.0a0
-    configupdater>=2.0,<3
+    configupdater>=2.0,<4
     packaging>=20.7
 
 [options.packages.find]


### PR DESCRIPTION
Right now we cannot run `pip install 'PyScaffold[all]==4.1'` because it requires ConfigUpdater>=3.

This PR relaxes the ConfigUpdater requirement, so we can have PyScaffold 4.1.