### PR TITLE
Separate publish instruction for GitHub Actions

### DIFF
--- a/src/pyscaffoldext/custom_extension/templates/publish_package.template
+++ b/src/pyscaffoldext/custom_extension/templates/publish_package.template
@@ -29,4 +29,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m pip install --upgrade pip setuptools tox
-        python -m tox -e clean,build,publish -- --verbose --repository pypi
+        python -m tox -e clean,build
+        python -m tox publish -- --verbose --repository pypi


### PR DESCRIPTION
In pyscaffold/pyscaffold#535, I introduced optional arguments for `tox -e build` and made `--wheel` the default.

Therefore the best is to separate the instructions for publishing in the GitHub Actions template to prevent errors.