### PR TITLE
Fix pre-commit repo initialsation due to unsupported protocol error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^docs/conf.py'
 
 repos:
-- repo: git://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.1.0
   hooks:
   - id: trailing-whitespace


### PR DESCRIPTION
Fixes [issue reported in pyscaffoldext-dsproject](https://github.com/pyscaffold/pyscaffoldext-dsproject/issues/47).