### PR TITLE
Better integration with upcoming GitHub Actions extension

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -10,8 +10,22 @@ def test_files(tmpfolder):
     files = (
         "README.rst",
         "CONTRIBUTING.rst",
+        ".cirrus.yml",
         ".pre-commit-config.yaml",
         ".github/workflows/publish-package.yml",
     )
     for file in files:
         assert Path("pyscaffoldext-some_extension", file).exists()
+
+
+def test_files_when_other_ci_is_used(tmpfolder):
+    # CustomExtension should not produce files if other CI extension is used
+    args = ["--no-config", "--gitlab", "--custom-extension", "pyscaffoldext-otherext"]
+    # --no-config: avoid extra config from dev's machine interference
+    cli.main(args)
+    files = (
+        ".cirrus.yml",
+        ".github/workflows/publish-package.yml",
+    )
+    for file in files:
+        assert not Path("pyscaffoldext-otherext", file).exists()


### PR DESCRIPTION
In pyscaffold/pyscaffold#619 we are proposing a new `--github-actions` extension to PyScaffold that will add a workflow that already contains the publish action[^1].

Ideally we want to avoid `--github-actions` and `--custom-extension` to created repeated CI actions.
Moreover, if the user wants to use `--github-actions` or `--gitlab` (or `--bitbucket-ci`, etc), it is highly unlikely that `--cirrus` should automatically be added to the mix.

In this PR, I attempt to postpone the automatic inclusion of `--cirrus`, and prevent it from happening entirely if `--github-actions` or `--gitlab` have been explicitly passed.

[^1]: The reason why the same workflow file contains both the tests and the publish job is because GitHub currently has no easy way of expressing dependencies between different workflows. This way unless everything is in the same file there is no way of preventing a release to proceed when the tests fail.